### PR TITLE
Look for the right port when patching up restservice config

### DIFF
--- a/docl/resources/update_running_system.py
+++ b/docl/resources/update_running_system.py
@@ -62,8 +62,8 @@ def fix_ip_in_files(ip):
          "db_address: '.*'",
          "db_address: '{ip}'"),
         ('/opt/manager/cloudify-rest.conf',
-         "amqp_address: '.*:5672/'",
-         "amqp_address: '{ip}:5672/'"),
+         "amqp_address: '.*:5671/'",
+         "amqp_address: '{ip}:5671/'"),
         ('/etc/logstash/conf.d/logstash.conf',
          'host => ".*"',
          'host => "{ip}"')


### PR DESCRIPTION
We're replacing the ip by looking for strings of the form "ip:port"
in the config file, but instead of looking for 5672, we should be
looking for 5671, because that's the port that is currently used
(after cloudify-cosmo/cloudify-manager-blueprints#508 )